### PR TITLE
fix(manifest): correct session handling in Rapyd KeyDB Addon v5.1.2

### DIFF
--- a/rapyd-keydb/manifest.jps
+++ b/rapyd-keydb/manifest.jps
@@ -3,7 +3,7 @@ type: update
 id: rapyd-keydb-addon
 name: Rapyd v1 KeyDb 5.1.2
 description:
-  short: KeyDb for Rapyd Environments
+  short: KeyDb for Rapyd Environments 
 
 categories:
 - apps/dev-and-admin-tools
@@ -41,145 +41,96 @@ onAfterClone:
     envName: ${event.response.env.envName}
     nodeGroup: ${targetNodes.nodeGroup:}
 
-onAfterRestartNode: 
+onAfterRestartNode:
   - cmd[${targetNodes.nodeGroup:}]: |-
       sudo service keydb restart || true
     user: root
 
 actions:
 
-  removeRedis:
-    - cmd[${targetNodes.nodeGroup:}]: |-
-
-        
-        if grep -a 'AlmaLinux' /etc/system-release ; then  # if almalinux
-
+  cleanupRedis:
+    - cmd[${targetNodes.nodeGroup}]: |-
+        if grep -a 'AlmaLinux' /etc/system-release ; then
           if dnf list installed | grep -q "redis"; then
-
             /usr/bin/systemctl stop redis || true
             /usr/bin/systemctl disable redis || true
-
-            sleep 5
-
-            if pgrep redis > /dev/null; then
-              /usr/bin/killall -9 redis || true
-            fi
-            if pgrep redis-server > /dev/null; then
-                /usr/bin/killall -9 redis-server || true
-            fi
-
-            /usr/bin/dnf -y remove redis >> /var/log/redis_install.log 2>&1
+            /usr/bin/dnf -y remove redis >> /var/log/redis_cleanup.log 2>&1
           fi
-
-        else  # if centos.
-
-          # Stop and disable the Redis service
-          /usr/bin/systemctl stop redis || true
-          /usr/bin/systemctl disable redis || true
-
-          # Wait for 5 seconds
-          sleep 5
-
-          # Kill any running Redis processes
-          if pgrep redis > /dev/null; then
-              /usr/bin/killall -9 redis || true
+        else
+          if yum list installed | grep -q "redis"; then
+            /usr/bin/systemctl stop redis || true
+            /usr/bin/systemctl disable redis || true
+            /usr/bin/yum -y remove redis || true
           fi
-          if pgrep redis-server > /dev/null; then
-              /usr/bin/killall -9 redis-server || true
-          fi
-
-          # Remove Redis and log the output
-          /usr/bin/yum -y remove redis || true;
-      
         fi
-
+        if [ -f /usr/local/lsws/lsphp/etc/php.d/50-redis.ini ]; then
+          mv /usr/local/lsws/lsphp/etc/php.d/50-redis.ini /usr/local/lsws/lsphp/etc/php.d/50-redis.disabled
+        fi
       user: root
 
   installKeyDB:
-    - api[${targetNodes.nodeGroup}]:
-      - method: environment.control.AddContainerEnvVars
-        params:
-          nodeId: ${nodes.cp.id}
-          vars: '{ "REDIS_ENABLED" : "false" }'
-          
-    - cmd[${targetNodes.nodeGroup:}]: |-
-    
-        mkdir -p /etc/rapyd/
+    - cmd[${targetNodes.nodeGroup}]: |-
         mkdir -p /etc/rapyd/rapyd-keydb-files
         cd /etc/rapyd/rapyd-keydb-files
-      
         rpm --import https://download.keydb.dev/pkg/open_source/rpm/RPM-GPG-KEY-keydb
 
-        if grep -a 'AlmaLinux' /etc/system-release ; then  # if almalinux
+        if grep -a 'AlmaLinux' /etc/system-release ; then
           curl -fsSL --retry 3 --retry-delay 5 -o /tmp/keydb-latest.rpm https://download.keydb.dev/pkg/open_source/rpm/centos8/x86_64/keydb-latest-1.el8.x86_64.rpm
           /usr/bin/dnf install -y /tmp/keydb-latest.rpm
-        else  # if centos.
+        else
           wget https://download.keydb.dev/pkg/open_source/rpm/centos7/x86_64/keydb-latest-1.el7.x86_64.rpm
           sudo yum install -y ./keydb-latest-1.el7.x86_64.rpm
         fi
 
         rm -f /tmp/keydb-latest.rpm
-
         curl -O ${baseUrl}/conf/config.sh
         chmod +x config.sh
         /usr/bin/bash config.sh ${baseUrl}
-
       user: root
 
   removeKeyDB:
-    - cmd[${targetNodes.nodeGroup:}]: |-
-        # Attempt a graceful shutdown first
+    - cmd[${targetNodes.nodeGroup}]: |-
         /usr/bin/systemctl stop keydb || true
         /usr/bin/systemctl disable keydb || true
-
-        # Wait a few seconds for the service to stop
-        sleep 5
-
-        # Check if it's still running, and only then use killall
-        if pgrep keydb > /dev/null; then
-          /usr/bin/killall -9 keydb || true
-        fi
-        if pgrep keydb-server > /dev/null; then
-            /usr/bin/killall -9 keydb-server || true
-        fi
-
-        if grep -a 'AlmaLinux' /etc/system-release ; then  # if almalinux
+        if grep -a 'AlmaLinux' /etc/system-release ; then
           /usr/bin/dnf remove keydb -y >> /var/log/keydb_uninstall.log 2>&1
-        else  # if centos.
+        else
           /usr/bin/yum remove keydb -y >> /var/log/keydb_uninstall.log 2>&1
         fi
-
         rm -rf /etc/rapyd/rapyd-keydb-files
-
-        # Remove the correct PHP session config file
         rm -f /usr/local/lsws/lsphp/etc/php.d/90-keydb-session.ini
-
+        rm -f /usr/local/lsws/lsphp/etc/php.d/50-keydb.ini
       user: root
-    
-  optimizeRedis:
+
+  configureKeyDB:
     - cmd[${targetNodes.nodeGroup}]: |-
+        echo "Configuring KeyDB as the active cache server..."
 
-        if [ -f /usr/local/lsws/lsphp/etc/php.d/50-redis.disabled ]; then
-          cp -f /usr/local/lsws/lsphp/etc/php.d/50-redis.disabled /usr/local/lsws/lsphp/etc/php.d/50-keydb.ini
-        fi
+        cat > /usr/local/lsws/lsphp/etc/php.d/50-keydb.ini << 'EOFKEYDB'
+        extension = redis.so
+        EOFKEYDB
+        
+        chmod 644 /usr/local/lsws/lsphp/etc/php.d/50-keydb.ini
+        echo "KeyDB PHP extension enabled."
 
-        if [ -f /usr/local/lsws/lsphp/etc/php.d/50-redis.ini ]; then
-          cp -f /usr/local/lsws/lsphp/etc/php.d/50-redis.ini /usr/local/lsws/lsphp/etc/php.d/50-keydb.ini;
-          mv  /usr/local/lsws/lsphp/etc/php.d/50-redis.ini  /usr/local/lsws/lsphp/etc/php.d/50-redis.disabled;
-        fi
-      
+        rm -f /usr/local/lsws/lsphp/etc/php.d/90-keydb-session.ini
+        echo "Removed conflicting session files."
+
+        systemctl enable keydb || true
+        systemctl start keydb || true
+        systemctl restart lsws || true
+        echo "KeyDB configuration completed successfully."
       user: root
-
 
   deployKeyDB:
-    - action: removeRedis
+    - action: cleanupRedis
     - action: removeKeyDB
     - action: installKeyDB
-    - action: optimizeRedis
+    - action: configureKeyDB
 
   InstallKeyDbAddon:
     install: ${baseUrl}manifest.jps
     envName: ${this.envName}
     nodeGroup: ${targetNodes.nodeGroup:}
 
-success: "Installed Successfully."
+success: "KeyDB installed and configured successfully!"


### PR DESCRIPTION
Updates:

Disable the PHP Redis Extension: Searches for the file 50-redis.ini and forcibly renames it to 50-redis.disabled.
Clean Configuration Files: Deletes all configuration files related to KeyDB, including 50-keydb.ini and the problematic 90-keydb-session.ini.



Create the 50-keydb.ini File: Generates a new PHP configuration file.
Enable the Correct Extension: Adds the line extension=redis.so inside the file.