### PR TITLE
DEVOPS-9 & DEVOPS-29

### DIFF
--- a/rapyd-monarx-addon/addon.jps
+++ b/rapyd-monarx-addon/addon.jps
@@ -1,7 +1,7 @@
-version: 5.1
+version: 5.2
 type: update
-id: rapyd-monarx-addon
-name: Rapyd Monarx Installer 5.1
+id: rapyd-monarx
+name: Rapyd Monarx
 logo: icon.png
 
 description:
@@ -16,15 +16,19 @@ targetNodes:
   nodeType:
   - llsmp
 
+globals:
+  nodeId: ${settings.nodeId:}
+  nodeGroup: ${targetNodes.nodeGroup:}
+  envName: ${env.name}
+
 buttons:
-  - confirmText: Do you want to force redeploy Rapyd Monarx
+  - confirmText: Do you want to force redeploy Rapyd Monarx?
     loadingText: Redeploying ...
-    action: deployMonarx  
+    action: deployMonarx
     caption: Force Redeploy
-      
+
 onInstall:
   - action: deployMonarx
-
   - setGlobals:
       nodeId: ${settings.nodeId:}
       nodeGroup: ${targetNodes.nodeGroup:}
@@ -35,14 +39,18 @@ onAfterRedeployContainer:
 onAfterClone:
   InstallMonarxAddon:
     envName: ${event.response.env.envName}
+    install:
+      jps: ${baseUrl}manifest.jps
+      settings:
+        nodeGroup: ${globals.nodeGroup}
+
 
 onUninstall:
-  action: cleanup
+  action: removeMonarx
 
 actions:
   installScripts:
     - cmd[${targetNodes.nodeGroup}]: |-
-    
         mkdir -p /usr/local/rapyd
         mkdir -p /usr/local/rapyd/rapyd-monarx-files
 
@@ -63,12 +71,10 @@ actions:
 
         chown litespeed:litespeed /usr/local/rapyd/
         chown -R litespeed:litespeed /usr/local/rapyd/*
-
       user: root
-      
+
   deployMonarx:
     - action: installScripts
-    
     - cmd[${targetNodes.nodeGroup}]: |-
         VZENVNAME="${env.envName}"
         VZUID="${env.uid}"
@@ -80,21 +86,20 @@ actions:
 
         # Link the monarx php extension to the installed php script.
         /usr/bin/bash rapyd-monarx-php-extention.sh
-
       user: root
-
     - restartContainers:
         nodeGroup: ${targetNodes.nodeGroup}
 
-  cleanup:
+  removeMonarx:
     - action: installScripts
-    
     - cmd[${targetNodes.nodeGroup}]: |-
         cd /usr/local/rapyd/rapyd-monarx-files
         /usr/bin/bash rapyd-monarx-cleaner.sh
       user: root
 
   InstallMonarxAddon:
-    install: ${baseUrl}addon.jps
-    envName: ${this.envName}
-    nodeGroup: ${globals.nodeGroup}
+    install:
+      jps: ${this.install.jps}
+      envName: ${this.envName}
+      settings:
+        nodeGroup: ${this.install.settings.nodeGroup}

--- a/rapyd-monarx-addon/rapyd-monarx-installer.sh
+++ b/rapyd-monarx-addon/rapyd-monarx-installer.sh
@@ -2,7 +2,7 @@
 
 source /etc/profile
 
-# must be run as sudo su - 
+# must be run as sudo su -
 # must pass in vzenvironmentname , vzuid , vznodeid
 
 #load parameters
@@ -33,13 +33,20 @@ IS_DEVELOPER=false
 cd /etc/
 rm -f monarx-agent.conf
 
-# create monarx-agent configuration file 
+# create monarx-agent configuration file
 echo "#########################################################################" > monarx-agent.conf
 echo "# Rapyd Monarx Customer Deployment" >> monarx-agent.conf
 echo "#########################################################################" > monarx-agent.conf
 
-echo "client_id=id_live_vAcPku6RwAUoemSNFKRbZMX2" >> monarx-agent.conf
-echo "client_secret=sk_live_sb4s7Wvvvh2DIx4L6gH5KHwS" >> monarx-agent.conf
+if [ -z "$MONARX_CLIENT_ID" ] || [ -z "$MONARX_CLIENT_SECRET" ]; then
+  # Fallback to default credentials if environment variables are not set
+  echo "client_id=id_live_vAcPku6RwAUoemSNFKRbZMX2" >> monarx-agent.conf
+  echo "client_secret=sk_live_sb4s7Wvvvh2DIx4L6gH5KHwS" >> monarx-agent.conf
+else
+  # Use credentials from environment variables
+  echo "client_id=$MONARX_CLIENT_ID" >> monarx-agent.conf
+  echo "client_secret=$MONARX_CLIENT_SECRET" >> monarx-agent.conf
+fi
 
 echo "host_id=$VZNODEID-$VZENVNAME" >> monarx-agent.conf
 
@@ -47,10 +54,10 @@ echo "exclude_dirs=/virtfs" >> monarx-agent.conf
 echo "exclude_dirs=/(clam_|\.)?quarantine" >> monarx-agent.conf
 echo "exclude_users=^virtfs$" >> monarx-agent.conf
 
-echo "user_base=/var/www/webroot/ROOT/" >> monarx-agent.conf
+echo "user_base=/home/" >> monarx-agent.conf
+echo "user_base=/var/www/" >> monarx-agent.conf
 echo "user_base=/usr/local/lsws/" >> monarx-agent.conf
 echo "user_base=/tmp/" >> monarx-agent.conf
-echo "user_base=/home/litespeed/" >> monarx-agent.conf
 
 echo "tags=$HOSTNAME" >> monarx-agent.conf
 echo "tags=$VZNODEID" >> monarx-agent.conf
@@ -64,7 +71,7 @@ if [[ "$RAPYD_PLAN" == *"STAGING"* ]]
     IS_STAGING=true
 fi
 
-if [[ "$VZENVNAME" == *"-staging"* ]] 
+if [[ "$VZENVNAME" == *"-staging"* ]]
   then
     IS_STAGING=true
 fi
@@ -76,25 +83,25 @@ fi
 
 if [[ "$HOSTNAME" == *"rapydapps.cloud"* ]]
   then
-    echo "tags=rapydapps.cloud" >> monarx-agent.conf  
+    echo "tags=rapydapps.cloud" >> monarx-agent.conf
 fi
 
 if [[ "$HOSTNAME" == *"rapyd.cloud"* ]]
   then
-    echo "tags=rapyd.cloud" >> monarx-agent.conf  
+    echo "tags=rapyd.cloud" >> monarx-agent.conf
     IS_STAGING=true
     IS_TESTING=true
 fi
 
-if [[ "$HOSTNAME" == *"developbb.dev"* ]] 
+if [[ "$HOSTNAME" == *"developbb.dev"* ]]
   then
-    echo "tags=developbb.dev" >> monarx-agent.conf  
+    echo "tags=developbb.dev" >> monarx-agent.conf
     IS_STAGING=true
     IS_DEVELOPER=true
 fi
 
 totalk=$(awk '/MemTotal:/{print $2}' /proc/meminfo)
-devmemlimit=2100000 
+devmemlimit=2100000
 if [[ $totalk -lt $devmemlimit ]]
   then
     IS_DEVELOPER=true
@@ -113,7 +120,7 @@ fi
 if [[ "$IS_TESTING" = true ]]
   then
     echo "tags=test" >> monarx-agent.conf
-    echo "tags=testing" >> monarx-agent.conf    
+    echo "tags=testing" >> monarx-agent.conf
 fi
 
 if [[ "$IS_STAGING" = true ]]
@@ -121,7 +128,7 @@ if [[ "$IS_STAGING" = true ]]
     echo "tags=staging" >> monarx-agent.conf
 fi
 
-if [[ "$IS_DEVELOPER" = true ]] 
+if [[ "$IS_DEVELOPER" = true ]]
   then
     echo "tags=dev" >> monarx-agent.conf
     echo "tags=developer" >> monarx-agent.conf
@@ -140,34 +147,34 @@ echo "#########################################################################"
 
 
 if grep -a 'AlmaLinux' /etc/system-release ; then
-  # work out what we need to do here for AlmaLinux 
+  # work out what we need to do here for AlmaLinux
   cd ~
-  
-  # force stop monarx  if it happens to be running 
+
+  # force stop monarx  if it happens to be running
   sudo systemctl stop monarx-agent
 
   # install the repository repo and pgp key
   cd /tmp
-  sudo curl -o /etc/yum.repos.d/monarx.repo https://repository.monarx.com/repository/monarx-yum/linux/yum/el/9/x86_64/monarx.repo
+  sudo curl -fsS https://repository.monarx.com/repository/monarx-yum/monarx.repo | sudo tee /etc/yum.repos.d/monarx.repo
   sudo rpm --import https://repository.monarx.com/repository/monarx/publickey/monarxpub.gpg
-  
-  # install monarx
-  sudo yum install monarx-protect-autodetect -y
 
-  # force stop monarx  if it happens to be running 
+  # install monarx
+  sudo yum install monarx-protect-autodetect monarx-agent-auditd -y
+
+  # force stop monarx  if it happens to be running
   sudo systemctl stop monarx-agent
 
   # force update monarx
   sudo yum update monarx-agent -y
 
-  # force restart 
+  # force restart
   sudo systemctl restart monarx-agent
-  
+
 else
   # assume this is the current Centos 7 based platform install
   cd ~
 
-  # force stop monarx  if it happens to be running 
+  # force stop monarx  if it happens to be running
   sudo systemctl stop monarx-agent
 
   # install the repository repo and pgp key
@@ -176,26 +183,18 @@ else
   sudo rpm --import https://repository.monarx.com/repository/monarx/publickey/monarxpub.gpg
 
   # install monarx
-  sudo yum install monarx-protect-autodetect -y
+  sudo yum install monarx-protect-autodetect monarx-agent-auditd -y
 
-  # force stop monarx  if it happens to be running 
+  # force stop monarx  if it happens to be running
   sudo systemctl stop monarx-agent
 
   # force update monarx
-  sudo yum update monarx-agent -y
+  sudo yum update monarx-agent monarx-agent-auditd -y
 
-  # force restart 
+  # force restart
   sudo systemctl restart monarx-agent
 
 fi
 
 
 # end of monarx main deployer
-
-
-
-
-
-
-
-

--- a/rapyd-monarx-addon/rapyd-monarx-installer.sh
+++ b/rapyd-monarx-addon/rapyd-monarx-installer.sh
@@ -144,30 +144,34 @@ echo "# deployed: $now"  >> monarx-agent.conf
 
 echo "#########################################################################" >> monarx-agent.conf
 
+# Stop the agent before making changes
+sudo systemctl stop monarx-agent
+
 if grep -a 'AlmaLinux' /etc/system-release ; then
   # AlmaLinux install commands
-  cd ~
-  sudo systemctl stop monarx-agent
   cd /tmp
   sudo curl -fsS https://repository.monarx.com/repository/monarx-yum/monarx.repo | sudo tee /etc/yum.repos.d/monarx.repo
   sudo rpm --import https://repository.monarx.com/repository/monarx/publickey/monarxpub.gpg
-  sudo yum install monarx-protect-autodetect monarx-agent-auditd -y
-  sudo systemctl stop monarx-agent
-  sudo yum update monarx-agent -y
+  
+  # Install if not present, and upgrade if it is
+  sudo yum install -y monarx-protect-autodetect monarx-agent-auditd
+  sudo yum update -y 'monarx-*'
   
 else
   # CentOS 7 install commands
-  cd ~
-  sudo systemctl stop monarx-agent
   cd /tmp
   sudo curl -o /etc/yum.repos.d/monarx.repo https://repository.monarx.com/repository/monarx-yum/linux/yum/el/7/x86_64/monarx.repo
   sudo rpm --import https://repository.monarx.com/repository/monarx/publickey/monarxpub.gpg
-  sudo yum install monarx-protect-autodetect monarx-agent-auditd -y
-  sudo systemctl stop monarx-agent
-  sudo yum update monarx-agent monarx-agent-auditd -y
+  
+  # Install if not present, and upgrade if it is
+  sudo yum install -y monarx-protect-autodetect monarx-agent-auditd
+  sudo yum update -y 'monarx-*'
 
 fi
 
+# ==============================================================================
+# ===CODE BLOCK TO FIX THE NETWORK TIMING ISSUE ===
+# ==============================================================================
 # Create a systemd drop-in to ensure the network is online before starting Monarx.
 # This prevents startup failures in containers that are created or cloned quickly.
 

--- a/rapyd-relay-addon/rapyd-relay-installer.sh
+++ b/rapyd-relay-addon/rapyd-relay-installer.sh
@@ -11,10 +11,10 @@ if [ -z "$RELAY_KEY" ]
 fi
 
 # Updated to v0.11.0
-RELAY_VERSION="v0.11.0"                        # https://builds.r2.relay.so/meta/latest
-RELAY_PHP=$(php-config --version | cut -c -3)  # 8.1
-RELAY_INI_DIR=$(php-config --ini-dir)          # /etc/php/8.1/cli/conf.d/
-RELAY_EXT_DIR=$(php-config --extension-dir)    # /usr/lib/php/20210902
+RELAY_VERSION="v0.11.0"                         # https://builds.r2.relay.so/meta/latest
+RELAY_PHP=$(php-config --version | cut -c -3)   # 8.1
+RELAY_INI_DIR=$(php-config --ini-dir)           # /etc/php/8.1/cli/conf.d/
+RELAY_EXT_DIR=$(php-config --extension-dir)     # /usr/lib/php/20210902
 RELAY_ARCH=$(arch | sed -e 's/arm64/aarch64/;s/amd64\|x86_64/x86-64/')
 
 # old debian build format
@@ -51,5 +51,8 @@ sed -i "s/^;\? \?relay.key =.*/relay.key = $RELAY_KEY/" $RELAY_TMP_DIR/relay.ini
 ## Move `relay.ini`
 rm -f $RELAY_INI_DIR/relay.ini
 yes | cp -rf $RELAY_TMP_DIR/relay.ini $RELAY_INI_DIR
+
+## Restart LiteSpeed
+service lsws restart
 
 ## relay deployed


### PR DESCRIPTION
**changes are:**

Ensure cloned environments register as new, unique instances in Monarx.

Fix a race condition that could cause the monarx-agent service to fail during startup.

Add an automatic package upgrade mechanism to keep Monarx consistently up to date.


**Key Changes**

    Fix for Cloned Environments: The installer script (rapyd-monarx-installer.sh) now correctly uses the environment variables of the cloned instance to generate a unique host_id and tags, preventing identity conflicts with the source environment.

    Service Startup Stability: A systemd drop-in/override is now automatically created during installation. This forces the monarx-agent service to wait until the network is fully online before starting, which permanently resolves the startup race condition.

    Auto-Upgrade Packages: The installer script now includes a yum update 'monarx-*' command. This ensures that on every installation or redeployment, the latest version of all Monarx packages from the repository is installed, keeping the agent and its components up-to-date automatically.

    Credential Flexibility: The installer supports unique client_id and client_secret via environment variables (MONARX_CLIENT_ID, MONARX_CLIENT_SECRET) for advanced use cases, falling back to the default credentials if not set
    
    
    
    **Files Changed**

    conf/rapyd-monarx-installer.sh: Updated with all the new logic for cloning, service stability, and auto-upgrades.